### PR TITLE
One line fixed for Qt6. Linux installation added in README .

### DIFF
--- a/README
+++ b/README
@@ -23,6 +23,26 @@ Support for Windows is very new, there might be a few things missing. Still to b
 
 Kajongg is part of the KDE games, your Linux distribution should bring it to you.
 
+This should work for most distros:
+
+However, for kajongg master, install from software manager:
+
+git
+Python3-pip
+Python3-qtpy
+python3-pyqt6
+python3-pyqt6.qtsvg
+Python3-twisted
+kdegames-mahjongg-data-kf5
+
+(instead of pyqt6, pyside6 would also do)
+
+Then open a terminal window and enter
+
+git clone https://github.com/KDE/kajongg.git
+cd kajongg/src
+./kajongg.py
+
 
 [b][u]More[/b][/u]
 

--- a/src/kdestub.py
+++ b/src/kdestub.py
@@ -108,7 +108,7 @@ class KApplication(QApplication):
     def desktopSize(cls) -> QSize:
         """The size of the current screen"""
         try:
-            result = Internal.app.desktop().availableGeometry()
+            result = QGuiApplication.primaryScreen().availableGeometry()
         except AttributeError:
             assert Internal.mainWindow
             screen = Internal.mainWindow.screen()


### PR DESCRIPTION
Hi, I have followed instructions from https://bugs.kde.org/show_bug.cgi?id=254918

Now it is running but :
* Needed to install kdegames-mahjongg-data-kf5 (with a lower case k) not Kdegames-mahjongg-data-kf5
* Had to change a line in kdestub.py

So here is the modest pull request !

Thanks a lot